### PR TITLE
Configurable default target identifier for object linking

### DIFF
--- a/Kernel/Config/Files/ITSMTicket.xml
+++ b/Kernel/Config/Files/ITSMTicket.xml
@@ -661,6 +661,14 @@
             </Hash>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="Frontend::AgentLinkObject::DefaultTargetIdentifier" Required="1" Valid="1">
+        <Description Translatable="1">Defines default link target type for Link ticket option on AgentTicketEmail and AgentTicketPhone screens. Examples: ITSMConfigItem, Ticket.</Description>
+        <Group>Framework</Group>
+        <SubGroup>Frontend::Agent::LinkObject</SubGroup>
+        <Setting>
+            <String Regex="">ITSMConfigItem</String>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="Ticket::Frontend::AgentTicketPhone###ShowIncidentState" Required="1" Valid="1">
         <Description Translatable="1">Defines if the service incident state should be shown during service selection in the agent interface.</Description>
         <Group>Ticket</Group>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -534,7 +534,7 @@ $('#NewResponsibleID').bind('change', function (Event) {
 # ---
 # ITSM
 # ---
-                        <a href="[% Env("Baselink") %]Action=AgentLinkObject;Mode=Temporary;SourceObject=Ticket;SourceKey=[% Data.FormID | uri %];TargetIdentifier=ITSMConfigItem" id="OptionLinkTicket" class="AsPopup">[ [% Translate("Link ticket") | html %] ]</a>
+                        <a href="[% Env("Baselink") %]Action=AgentLinkObject;Mode=Temporary;SourceObject=Ticket;SourceKey=[% Data.FormID | uri %];TargetIdentifier=[% Config("Frontend::AgentLinkObject::DefaultTargetIdentifier") %]" id="OptionLinkTicket" class="AsPopup">[ [% Translate("Link ticket") | html %] ]</a>
 # ---
 
 <!-- OutputFilterHook_TicketOptionsEnd -->

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -389,7 +389,7 @@
 # ---
 # ITSM
 # ---
-                        <a href="[% Env("Baselink") %]Action=AgentLinkObject;Mode=Temporary;SourceObject=Ticket;SourceKey=[% Data.FormID | uri %];TargetIdentifier=ITSMConfigItem" id="OptionLinkTicket" class="AsPopup">[ [% Translate("Link ticket") | html %] ]</a>
+                        <a href="[% Env("Baselink") %]Action=AgentLinkObject;Mode=Temporary;SourceObject=Ticket;SourceKey=[% Data.FormID | uri %];TargetIdentifier=[% Config("Frontend::AgentLinkObject::DefaultTargetIdentifier") %]" id="OptionLinkTicket" class="AsPopup">[ [% Translate("Link ticket") | html %] ]</a>
 # ---
 
 <!-- OutputFilterHook_TicketOptionsEnd -->


### PR DESCRIPTION
This mod introduces new SysConfig parameter
`Frontend::AgentLinkObject::DefaultTargetIdentifier` that defines default
link target type for Link ticket option on AgentTicketEmail
and AgentTicketPhone screens. Examples: ITSMConfigItem (default like in
standard OTRS), Ticket (may be useful in case of manual creating many
tickets with links to other tickets).

Related: https://dev.ib.pl/ib/otrs-ext/issues/1
Author-Change-Id: IB#1020832
