### PR TITLE
Calls to old Get() method replaced with calls to new Translate() method

### DIFF
--- a/Kernel/Modules/AgentTicketActionCommon.pm
+++ b/Kernel/Modules/AgentTicketActionCommon.pm
@@ -1085,7 +1085,7 @@ sub Run {
             # build the response
             %Response = (
                 CurInciSignal => $InciSignals{ $Service{CurInciStateType} },
-                CurInciState  => $LayoutObject->{LanguageObject}->Get($Service{CurInciState}),
+                CurInciState  => $LayoutObject->{LanguageObject}->Translate($Service{CurInciState}),
             );
         }
 

--- a/Kernel/Modules/AgentTicketEmail.pm
+++ b/Kernel/Modules/AgentTicketEmail.pm
@@ -1640,7 +1640,7 @@ sub Run {
             # build the response
             %Response = (
                 CurInciSignal => $InciSignals{ $Service{CurInciStateType} },
-                CurInciState  => $LayoutObject->{LanguageObject}->Get($Service{CurInciState}),
+                CurInciState  => $LayoutObject->{LanguageObject}->Translate($Service{CurInciState}),
             );
         }
 

--- a/Kernel/Modules/AgentTicketPhone.pm
+++ b/Kernel/Modules/AgentTicketPhone.pm
@@ -1844,7 +1844,7 @@ sub Run {
             # build the response
             %Response = (
                 CurInciSignal => $InciSignals{ $Service{CurInciStateType} },
-                CurInciState  => $LayoutObject->{LanguageObject}->Get($Service{CurInciState}),
+                CurInciState  => $LayoutObject->{LanguageObject}->Translate($Service{CurInciState}),
             );
         }
 


### PR DESCRIPTION
OTRS modules (ITSM, FAQ, Survey) still use an old Get() method
of Kernel::Language instead of new Translate() method.

This mod replaces Get() with Translate() for future compatibility.

https://dev.ib.pl/ib/otrs-ext/issues/2
Author-Change-Id: IB#1054073
