### PR TITLE
Improve wording, marked state as translatable

### DIFF
--- a/ITSMIncidentProblemManagement.sopm
+++ b/ITSMIncidentProblemManagement.sopm
@@ -71,8 +71,8 @@
     </Filelist>
     <DatabaseInstall Type="post">
         <Insert Table="ticket_state">
-            <Data Key="name" Type="Quote">closed with workaround</Data>
-            <Data Key="comments" Type="Quote">ticket is closed with workaround</Data>
+            <Data Key="name" Type="Quote" Translatable="1">closed with workaround</Data>
+            <Data Key="comments" Type="Quote">Ticket is closed with workaround.</Data>
             <Data Key="type_id">3</Data>
             <Data Key="valid_id">1</Data>
             <Data Key="create_time">current_timestamp</Data>


### PR DESCRIPTION
Hi @UdoBretz 
All ticket state comments are full sentence, see: https://github.com/OTRS/otrs/blob/rel-5_0/scripts/database/otrs-initial_insert.mysql.sql#L130-L183
This PR makes this state similar to others. I also marked the state as translatable. Please sync to Transifex after merging.